### PR TITLE
Return success when automatic fixes applied

### DIFF
--- a/src/Command/CheckCommand.php
+++ b/src/Command/CheckCommand.php
@@ -130,14 +130,17 @@ final class CheckCommand extends Command
             }
             $this->formatter->output($output, $violating, $totalSize, $humanSize);
 
+            $status = Command::FAILURE;
+
             if (!$isDryRun && $package === null) {
                 $this->gitAttributesManager->appendPatterns(violatingFilesAndDirs: $violating);
                 $output->writeln('<info>Patterns have been added to .gitattributes</info>');
+                $status = Command::SUCCESS;
             } elseif (!$isDryRun) {
                 $output->writeln('<comment>Note: --dry-run is ignored when checking a specific package</comment>');
             }
 
-            return Command::FAILURE;
+            return $status;
         } finally {
             $this->packageManager->cleanup();
         }

--- a/tests/Command/CheckCommandTest.php
+++ b/tests/Command/CheckCommandTest.php
@@ -7,6 +7,7 @@ namespace SavinMikhail\DistSizeOptimizer\Tests\Command;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use SavinMikhail\DistSizeOptimizer\Command\CheckCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 
@@ -50,6 +51,25 @@ final class CheckCommandTest extends TestCase
         self::assertArrayHasKey('directories', $result);
         self::assertArrayHasKey('totalSizeBytes', $result);
         self::assertArrayHasKey('humanReadableSize', $result);
+    }
+
+    public function testAutomaticFixReturnsSuccess(): void
+    {
+        $originalAttributes = file_exists(filename: '.gitattributes') ? file_get_contents(filename: '.gitattributes') : '';
+
+        $input = new ArrayInput(parameters: [
+            '--config' => $this->testConfigPath,
+        ]);
+        $output = new BufferedOutput();
+
+        try {
+            $exitCode = $this->command->run(input: $input, output: $output);
+
+            self::assertSame(Command::SUCCESS, $exitCode);
+            self::assertStringContainsString('README.md export-ignore', (string) file_get_contents(filename: '.gitattributes'));
+        } finally {
+            file_put_contents(filename: '.gitattributes', data: $originalAttributes);
+        }
     }
 
     public function testCheckPackageByName(): void


### PR DESCRIPTION
## Summary
- return success when files are automatically export-ignored
- add regression test for successful fix path

## Testing
- `vendor/bin/phpunit`
- `vendor/bin/phpstan` *(fails: Offset 'directories' does not exist and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b7d73de93083248c34ddef461f7094