### PR TITLE
feat: add dist-size badge workflow

### DIFF
--- a/.github/workflows/dist-size.yml
+++ b/.github/workflows/dist-size.yml
@@ -1,0 +1,39 @@
+name: dist-size
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          coverage: none
+      - name: Install dependencies
+        run: composer install --no-interaction --no-progress
+      - name: Run dist size check
+        id: dist
+        run: |
+          set +e
+          bin/dist-size-optimizer check --dry-run > /tmp/out.txt
+          exit_code=$?
+          cat /tmp/out.txt
+          if [ $exit_code -eq 0 ]; then
+            echo '{"schemaVersion":1,"label":"dist-size","message":"optimized","color":"brightgreen"}' > dist-size-status.json
+          else
+            echo '{"schemaVersion":1,"label":"dist-size","message":"needs optimization","color":"red"}' > dist-size-status.json
+          fi
+          echo "exit_code=$exit_code" >> $GITHUB_OUTPUT
+      - name: Commit status
+        if: github.event_name == 'push'
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: 'chore: update dist-size badge [skip ci]'
+          file_pattern: dist-size-status.json

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Dist Size Optimizer
 
+![dist-size status](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fsavinmikhail%2Fdist-size-optimizer%2Fmain%2Fdist-size-status.json)
+
 A command-line tool that helps you optimize your package distribution size by automatically managing `.gitattributes` export-ignore rules.
 
 > **Note**: This package was previously known as `export-ignore-check`. The functionality remains the same, but the name better reflects its purpose of optimizing distribution size.

--- a/dist-size-status.json
+++ b/dist-size-status.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "label": "dist-size",
+  "message": "optimized",
+  "color": "brightgreen"
+}


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to check distribution size and update badge JSON
- commit initial dist-size badge and show it in README

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68b7daba2b048324a33084584db754c5