### PR TITLE
Add keywords (static analysis, etc) in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name": "savinmikhail/dist-size-optimizer",
     "description": "Optimizes your package distribution size by automatically managing .gitattributes export-ignore rules",
     "license": "MIT",
+    "keywords": ["static analysis", "export-ignore", "dist", ".gitattributes"],
     "require": {
         "php": "^8.2",
         "symfony/console": "^7.2",


### PR DESCRIPTION
I suggest adding "keywords", mostly `static analysis` is special keyword to promote add into `require-dev`
https://getcomposer.org/doc/04-schema.md#keywords
> Note: Some special keywords trigger composer require without the --dev option to prompt users if they would like to add these packages to require-dev instead of require. These are: dev, testing, static analysis.