### PR TITLE
Apply php-cs-fixer fix

### DIFF
--- a/export-ignore.php
+++ b/export-ignore.php
@@ -8,9 +8,9 @@ return [
     'tests/',
     'Tests/',
     'docs/',
-    'tools/', // often used with bamarni/composer-bin-plugin 
+    'tools/', // often used with bamarni/composer-bin-plugin
     // dirs >>>
-    
+
     'dist-size-status.json', // used for badge "dist size optimized"
     '.gitignore',
     '.editorconfig',


### PR DESCRIPTION
`./vendor/bin/php-cs-fixer fix --dry-run --diff` got

```
   1) /home/sasezaki/dev/dist-size-optimizer/export-ignore.php
      ---------- begin diff ----------
--- /home/sasezaki/dev/dist-size-optimizer/export-ignore.php
+++ /home/sasezaki/dev/dist-size-optimizer/export-ignore.php
@@ -8,9 +8,9 @@
     'tests/',
     'Tests/',
     'docs/',
-    'tools/', // often used with bamarni/composer-bin-plugin
+    'tools/', // often used with bamarni/composer-bin-plugin
     // dirs >>>
-
+
     'dist-size-status.json', // used for badge "dist size optimized"
     '.gitignore',
     '.editorconfig',

      ----------- end diff -----------
```